### PR TITLE
Model HYPParsedRelationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,38 @@
 ## Usage
 
 ```objc
-- (NSDictionary *)hyp_parseRelationship;
+#import "NSString+HYPRelationshipParser.h"
+#import "HYPParsedRelationship.h"
+
+- (HYPParsedRelationship *)hyp_parseRelationship;
 ```
 
 ## Example
 
 ```objc
-NSDictionary *resultDict = [@"name" hyp_parseRelationship];
+HYPParsedRelationship *parsedRelationship = [@"name" hyp_parseRelationship];
 /*
 {
-    @"attribute": @"name"
+    parsedRelationship.attribute => @"name"
 };
 */
 
-NSDictionary *resultDict = [@"company.name" hyp_parseRelationship];
+HYPParsedRelationship *parsedRelationship = [@"company.name" hyp_parseRelationship];
 /*
 {
-    @"relationship" : @"company",
-    @"to_many" : @NO,
-    @"attribute": @"name"
+  parsedRelationship.relationship => @"company",
+  parsedRelationship.to_many => NO,
+  parsedRelationship.attribute => "name"
 };
 */
 
-NSDictionary *resultDict = [@"employees[0].email" hyp_parseRelationship];
+HYPParsedRelationship *parsedRelationship = [@"employees[0].email" hyp_parseRelationship];
 /*
 {
-    @"relationship" : @"employees",
-    @"index": @0,
-    @"to_many" : @YES,
-    @"attribute": @"email"
+    parsedRelationship.relationship => @"employees",
+    parsedRelationship.index => 0,
+    parsedRelationship.to_many => YES,
+    parsedRelationship.attribute => @"email"
 };
 */
 ```

--- a/Source/HYPParsedRelationship.h
+++ b/Source/HYPParsedRelationship.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+@interface HYPParsedRelationship : NSObject
+
+@property (nonatomic) NSString *relationship;
+@property (nonatomic) NSInteger index;
+@property (nonatomic) BOOL toMany;
+@property (nonatomic) NSString *attribute;
+
+@end

--- a/Source/HYPParsedRelationship.m
+++ b/Source/HYPParsedRelationship.m
@@ -1,0 +1,13 @@
+#import "HYPParsedRelationship.h"
+
+@implementation HYPParsedRelationship
+
+- (BOOL)isEqual:(HYPParsedRelationship *)object
+{
+    return ((!self.relationship || [self.relationship isEqualToString:object.relationship]) &&
+            self.index == object.index &&
+            self.toMany == object.toMany &&
+            (!self.attribute || [self.attribute isEqualToString:object.attribute]));
+}
+
+@end

--- a/Source/NSString+HYPRelationshipParser.h
+++ b/Source/NSString+HYPRelationshipParser.h
@@ -1,7 +1,9 @@
 @import Foundation;
 
+@class HYPParsedRelationship;
+
 @interface NSString (HYPRelationshipParser)
 
-- (NSDictionary *)hyp_parseRelationship;
+- (HYPParsedRelationship *)hyp_parseRelationship;
 
 @end

--- a/Source/NSString+HYPRelationshipParser.m
+++ b/Source/NSString+HYPRelationshipParser.m
@@ -1,48 +1,53 @@
 #import "NSString+HYPRelationshipParser.h"
 
+#import "HYPParsedRelationship.h"
+
 @implementation NSString (HYPRelationshipParser)
 
-- (NSDictionary *)hyp_parseRelationship
+- (HYPParsedRelationship *)hyp_parseRelationship
 {
+    HYPParsedRelationship *parsedRelationship;
+
     NSMutableCharacterSet *alphanumericSet = [NSMutableCharacterSet alphanumericCharacterSet];
     [alphanumericSet addCharactersInString:@"_"];
 
     BOOL valid = [[self stringByTrimmingCharactersInSet:alphanumericSet] isEqualToString:@""];
 
     if (valid) {
-        return @{@"attribute" : self};
+        parsedRelationship = [HYPParsedRelationship new];
+        parsedRelationship.attribute = self;
     } else {
         NSCharacterSet *set = [NSCharacterSet characterSetWithCharactersInString:@"[]."];
         NSRange range = [self rangeOfCharacterFromSet:set];
         BOOL isRelationship = (range.location != NSNotFound);
+
         if (isRelationship) {
             NSCharacterSet *toManySet = [NSCharacterSet characterSetWithCharactersInString:@"[]"];
             NSRange toManyRange = [self rangeOfCharacterFromSet:toManySet];
             BOOL isToManyRelationship = (toManyRange.location != NSNotFound);
+
             if (isToManyRelationship) {
-
                 NSScanner *scanner = [NSScanner scannerWithString:self];
-
-                NSString *relationship = nil;
+                NSString *relationship;
 
                 if ([scanner scanUpToString:@"[" intoString:&relationship]) {
-                    if (scanner.isAtEnd) {
-                        return nil;
-                    }
 
-                    scanner.scanLocation++;
+                    if (!scanner.isAtEnd) {
+                        scanner.scanLocation++;
 
-                    NSString *objectID = nil;
-                    if ([scanner scanUpToString:@"]" intoString:&objectID]) {
-                        scanner.scanLocation += 2;
+                        NSString *objectID;
+                        if ([scanner scanUpToString:@"]" intoString:&objectID]) {
+                            scanner.scanLocation += 2;
 
-                        NSString *name = nil;
-                        if ([scanner scanUpToString:@"\n" intoString:&name]) {
-                            if (relationship && objectID && name) {
-                                return @{@"relationship" : relationship,
-                                         @"index": @([objectID integerValue]),
-                                         @"to_many" : @YES,
-                                         @"attribute": name};
+                            NSString *name;
+                            if ([scanner scanUpToString:@"\n" intoString:&name]) {
+                                if (relationship && objectID && name) {
+                                    parsedRelationship = [HYPParsedRelationship new];
+                                    parsedRelationship.relationship = relationship;
+                                    parsedRelationship.index = [objectID integerValue];
+                                    parsedRelationship.toMany = YES;
+                                    parsedRelationship.attribute = name;
+                                }
                             }
                         }
                     }
@@ -54,15 +59,16 @@
                                                  [elements.firstObject length] > 0 &&
                                                  [elements.lastObject length] > 0);
                 if (isValidToOneRelationship) {
-                    return @{@"relationship" : [elements firstObject],
-                             @"to_many" : @NO,
-                             @"attribute" : [elements lastObject]};
+                    parsedRelationship = [HYPParsedRelationship new];
+                    parsedRelationship.relationship = [elements firstObject];
+                    parsedRelationship.toMany = NO;
+                    parsedRelationship.attribute = [elements lastObject];
                 }
             }
         }
     }
 
-    return nil;
+    return parsedRelationship;
 }
 
 @end

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		142513651AB9ADAF00E60E69 /* HYPParsedRelationship.m in Sources */ = {isa = PBXBuildFile; fileRef = 142513641AB9ADAF00E60E69 /* HYPParsedRelationship.m */; };
 		14A892B61A372C2000D36669 /* NSString+HYPRelationshipParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 14A892B51A372C2000D36669 /* NSString+HYPRelationshipParser.m */; };
 		14B564731A06D87B00342CDA /* .travis.yml in Resources */ = {isa = PBXBuildFile; fileRef = 14B564721A06D87B00342CDA /* .travis.yml */; };
 		14C4182E1A01919C00636FD6 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 14C4182D1A01919C00636FD6 /* Tests.m */; };
@@ -17,6 +18,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		142513631AB9ADAF00E60E69 /* HYPParsedRelationship.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HYPParsedRelationship.h; sourceTree = "<group>"; };
+		142513641AB9ADAF00E60E69 /* HYPParsedRelationship.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HYPParsedRelationship.m; sourceTree = "<group>"; };
 		14A892B41A372C2000D36669 /* NSString+HYPRelationshipParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+HYPRelationshipParser.h"; sourceTree = "<group>"; };
 		14A892B51A372C2000D36669 /* NSString+HYPRelationshipParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+HYPRelationshipParser.m"; sourceTree = "<group>"; };
 		14B564721A06D87B00342CDA /* .travis.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = .travis.yml; path = ../.travis.yml; sourceTree = "<group>"; };
@@ -81,6 +84,8 @@
 			children = (
 				14A892B41A372C2000D36669 /* NSString+HYPRelationshipParser.h */,
 				14A892B51A372C2000D36669 /* NSString+HYPRelationshipParser.m */,
+				142513631AB9ADAF00E60E69 /* HYPParsedRelationship.h */,
+				142513641AB9ADAF00E60E69 /* HYPParsedRelationship.m */,
 			);
 			name = Source;
 			path = ../Source;
@@ -175,6 +180,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14A892B61A372C2000D36669 /* NSString+HYPRelationshipParser.m in Sources */,
+				142513651AB9ADAF00E60E69 /* HYPParsedRelationship.m in Sources */,
 				14C4183F1A019A1500636FD6 /* README.md in Sources */,
 				14C4183C1A019A1500636FD6 /* CONTRIBUTING.md in Sources */,
 				14C4182E1A01919C00636FD6 /* Tests.m in Sources */,

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -1,6 +1,7 @@
 @import XCTest;
 
 #import "NSString+HYPRelationshipParser.h"
+#import "HYPParsedRelationship.h"
 
 @interface Tests : XCTestCase
 
@@ -8,79 +9,62 @@
 
 @implementation Tests
 
-- (void)testParseRelationship
+- (void)testParseRelationshipA
 {
-    NSString *testString = @"name";
-    NSDictionary *resultDict = @{@"attribute": @"name"};
+    HYPParsedRelationship *result = [HYPParsedRelationship new];
+    result.attribute = @"name";
 
-    XCTAssertEqualObjects(resultDict, [testString hyp_parseRelationship]);
-
-    testString = @"source_id";
-    resultDict = @{@"attribute": @"source_id"};
-
-    XCTAssertEqualObjects(resultDict, [testString hyp_parseRelationship]);
+    XCTAssertEqualObjects(result, [@"name" hyp_parseRelationship]);
 }
 
-- (void)testParseToManyRelationship
+- (void)testParseRelationshipB
 {
-    NSString *testString = @"relatives[0].first_name";
+    HYPParsedRelationship *result = [HYPParsedRelationship new];
+    result.attribute = @"source_id";
 
-    NSDictionary *evaluatedDict = @{@"relationship" : @"relatives",
-                                    @"index": @0,
-                                    @"to_many" : @YES,
-                                    @"attribute": @"first_name"};
-
-    NSDictionary *resultDict = [testString hyp_parseRelationship];
-
-    XCTAssertNotNil(resultDict);
-    XCTAssertEqualObjects([resultDict valueForKey:@"relationship"], @"relatives");
-    XCTAssertEqualObjects([resultDict valueForKey:@"index"], @0);
-    XCTAssertEqualObjects([resultDict valueForKey:@"to_many"], @YES);
-    XCTAssertEqualObjects([resultDict valueForKey:@"attribute"], @"first_name");
-
-    testString = @"relatives[1].email";
-
-    evaluatedDict = @{@"relationship" : @"relatives",
-                      @"index": @1,
-                      @"to_many" : @YES,
-                      @"attribute": @"email"};
-
-    resultDict = [testString hyp_parseRelationship];
-
-    XCTAssertNotNil(resultDict);
-    XCTAssertEqualObjects([resultDict valueForKey:@"relationship"], @"relatives");
-    XCTAssertEqualObjects([resultDict valueForKey:@"index"], @1);
-    XCTAssertEqualObjects([resultDict valueForKey:@"to_many"], @YES);
-    XCTAssertEqualObjects([resultDict valueForKey:@"attribute"], @"email");
+    XCTAssertEqualObjects(result, [@"source_id" hyp_parseRelationship]);
 }
 
-- (void)testParseToOneRelationship
+- (void)testParseToManyRelationshipA
 {
-    NSString *testString = @"contract.first_name";
+    HYPParsedRelationship *result = [HYPParsedRelationship new];
+    result.relationship = @"relatives";
+    result.index = 0;
+    result.toMany = YES;
+    result.attribute = @"first_name";
 
-    NSDictionary *evaluatedDict = @{@"relationship" : @"contract",
-                                    @"to_many" : @NO,
-                                    @"attribute" : @"first_name"};
+    XCTAssertEqualObjects([@"relatives[0].first_name" hyp_parseRelationship], result);
+}
 
-    NSDictionary *resultDict = [testString hyp_parseRelationship];
+- (void)testParseToManyRelationshipB
+{
+    HYPParsedRelationship *result = [HYPParsedRelationship new];
+    result.relationship = @"relatives";
+    result.index = 1;
+    result.toMany = YES;
+    result.attribute = @"email";
 
-    XCTAssertNotNil(resultDict);
-    XCTAssertEqualObjects([resultDict valueForKey:@"relationship"], @"contract");
-    XCTAssertEqualObjects([resultDict valueForKey:@"to_many"], @NO);
-    XCTAssertEqualObjects([resultDict valueForKey:@"attribute"], @"first_name");
+    XCTAssertEqualObjects([@"relatives[1].email" hyp_parseRelationship], result);
+}
 
-    testString = @"company.email";
+- (void)testParseToOneRelationshipA
+{
+    HYPParsedRelationship *result = [HYPParsedRelationship new];
+    result.relationship = @"contract";
+    result.toMany = NO;
+    result.attribute = @"first_name";
 
-    evaluatedDict = @{@"relationship" : @"company",
-                      @"to_many" : @NO,
-                      @"attribute" : @"email"};
+    XCTAssertEqualObjects([@"contract.first_name" hyp_parseRelationship], result);
+}
 
-    resultDict = [testString hyp_parseRelationship];
+- (void)testParseToOneRelationshipB
+{
+    HYPParsedRelationship *result = [HYPParsedRelationship new];
+    result.relationship = @"company";
+    result.toMany = NO;
+    result.attribute = @"email";
 
-    XCTAssertNotNil(resultDict);
-    XCTAssertEqualObjects([resultDict valueForKey:@"relationship"], @"company");
-    XCTAssertEqualObjects([resultDict valueForKey:@"to_many"], @NO);
-    XCTAssertEqualObjects([resultDict valueForKey:@"attribute"], @"email");
+    XCTAssertEqualObjects([@"company.email" hyp_parseRelationship], result);
 }
 
 - (void)testFaultyStrings


### PR DESCRIPTION
Using dictionary is error prone because strings 
Also you can’t use autocompletion and it’s not type safe.
This should fix that problem

Updated README => https://github.com/hyperoslo/NSString-HYPRelationshipParser/commit/12bbc1c7a9c1f7844ab6cf4f01c2e7ec078fb71e